### PR TITLE
Allow timer reset without clearing response

### DIFF
--- a/src/pages/Test.jsx
+++ b/src/pages/Test.jsx
@@ -15,6 +15,7 @@ export default function Test() {
     durationMins,
     isRunning,
     stop,
+    reset,
   } = useTestStore();
 
   const navigate = useNavigate();
@@ -54,6 +55,14 @@ export default function Test() {
       </div>
       <button
         onClick={() => {
+          reset();
+          setRemaining(durationMins * 60);
+        }}
+      >
+        Reset
+      </button>
+      <button
+        onClick={() => {
           stop();
           navigate('/');
         }}
@@ -63,4 +72,3 @@ export default function Test() {
     </div>
   );
 }
-

--- a/src/store/useTestStore.js
+++ b/src/store/useTestStore.js
@@ -18,6 +18,7 @@ import { create } from 'zustand';
  * @property {(taskKey:string, prompt:Prompt, durationMins:number) => void} start
  * @property {(response:string) => void} setResponse
  * @property {() => void} stop
+ * @property {() => void} reset
  */
 
 /** @type {import('zustand').UseBoundStore<import('zustand').StoreApi<TestState>>} */
@@ -41,5 +42,5 @@ export const useTestStore = create((set) => ({
     }),
   setResponse: (response) => set({ response }),
   stop: () => set({ isRunning: false }),
+  reset: () => set({ startedAt: Date.now(), isRunning: true }),
 }));
-


### PR DESCRIPTION
## Summary
- add reset action to keep response text when restarting timer
- wire Reset button to restart timer while preserving typed text

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_689e6f7a4f0c8329ad9f1b02726c96ec